### PR TITLE
check for inconsistencies in labels

### DIFF
--- a/autofig/__init__.py
+++ b/autofig/__init__.py
@@ -5,8 +5,13 @@ from figure import Figure
 global _figure
 _figure = None
 
+def reset():
+    global _figure
+    _figure = None
+
 def gcf():
     global _figure
+
     if _figure is None:
         _figure = Figure()
 

--- a/autofig/axes.py
+++ b/autofig/axes.py
@@ -116,11 +116,17 @@ class Axes(object):
         * compatible units in all directions
         * compatible independent-variable (if applicable)
         """
+        def _consistent_labels(label1, label2):
+            if label1 is None or label2 is None:
+                return True
+            else:
+                return label1 == label2
+
         if len(self.calls) == 0:
             return True, ''
 
         msg = []
-        # TODO: include c, fc, ec and make this into a loop
+        # TODO: include s, c, fc, ec, etc and make these checks into loops
         if call.x.unit.physical_type != self.x.unit.physical_type:
             msg.append('inconsitent xunit, {} != {}'.format(call.x.unit, self.x.unit))
         if call.y.unit.physical_type != self.y.unit.physical_type:
@@ -132,6 +138,14 @@ class Axes(object):
         if call.i.is_reference or self.i.is_reference:
             if call.i.reference != self.i.reference:
                 msg.append('inconsistent i reference, {} != {}'.format(call.i.reference, self.i.reference))
+
+        # here we send the protected _label so that we get None instead of empty string
+        if not _consistent_labels(call.x._label, self.x._label):
+            msg.append('inconsitent xlabel, {} != {}'.format(call.x.label, self.x.label))
+        if not _consistent_labels(call.y._label, self.y._label):
+            msg.append('inconsitent ylabel, {} != {}'.format(call.y.label, self.y.label))
+        if not _consistent_labels(call.z._label, self.z._label):
+            msg.append('inconsitent zlabel, {} != {}'.format(call.z.label, self.z.label))
 
 
         if len(msg):
@@ -169,11 +183,11 @@ class Axes(object):
             # will stick.  We check the protected underscored version to have
             # access to None instead of the empty string.
             if self.x._label is None:
-                self.x.label = call.x.label
+                self.x.label = call.x._label
             if self.y._label is None:
-                self.y.label = call.y.label
+                self.y.label = call.y._label
             if self.z._label is None:
-                self.z.label = call.z.label
+                self.z.label = call.z._label
 
     def append_subplot(self, fig=None):
         def determine_grid(N):

--- a/autofig/call.py
+++ b/autofig/call.py
@@ -405,8 +405,8 @@ class Dimension(object):
 
 
         if label is None:
-            # TODO: switch to default
-            label = ''
+            self._label = label
+            return
 
         if not isinstance(label, str):
             try:

--- a/tests/test_inconsistencies.py
+++ b/tests/test_inconsistencies.py
@@ -4,7 +4,15 @@ from nose.tools import assert_raises
 def test_unit_inconsistencies():
     # Bottom-Up
     call1 = autofig.Plot(x=[1,2,3], y=[1,2,3], xunit='solRad')
-    call2 = autofig.Plot(x=[1,2,3], y=[1,2,3], yunit='kg')
+    call2 = autofig.Plot(x=[1,2,3], y=[1,2,3])
+
+    # None should cause issues, regardless of order
+    assert_raises(ValueError, autofig.Axes, call1, call2)
+    assert_raises(ValueError, autofig.Axes, call2, call1)
+
+    # different provided values should cause inconsistency
+    call1 = autofig.Plot(x=[1,2,3], y=[1,2,3], xunit='solRad')
+    call2 = autofig.Plot(x=[1,2,3], y=[1,2,3], xunit='kg')
 
     assert_raises(ValueError, autofig.Axes, call1, call2)
 
@@ -16,5 +24,41 @@ def test_unit_inconsistencies():
     autofig.plot(x=[1,2,3], y=[1,2,3], xunit='km', yunit='kg')
     assert(len(autofig.gcf().axes)==2)
 
+def test_label_inconsistencies():
+    # Bottom-Up
+    call1 = autofig.Plot(x=[1,2,3], y=[1,2,3], xlabel='blah')
+    call2 = autofig.Plot(x=[1,2,3], y=[1,2,3])
+
+    # None shouldn't cause issues
+    ax = autofig.Axes(call1, call2)
+    assert(len(ax.calls)==2)
+    fig = autofig.Figure(call1, call2)
+    assert(len(fig.axes)==1)
+    assert(len(fig.calls)==2)
+
+    # None shouldn't cause issues if first either
+    ax = autofig.Axes(call2, call1)
+    assert(len(ax.calls)==2)
+    fig = autofig.Figure(call2, call1)
+    assert(len(fig.axes)==1)
+    assert(len(fig.calls)==2)
+
+    # different provided values should cause inconsistency
+    call1 = autofig.Plot(x=[1,2,3], y=[1,2,3], xlabel='blah')
+    call2 = autofig.Plot(x=[1,2,3], y=[1,2,3], xlabel='OTHER')
+
+    assert_raises(ValueError, autofig.Axes, call1, call2)
+
+    fig = autofig.Figure(call1, call2)
+    assert(len(fig.axes)==2)
+
+    # Top-down
+    autofig.reset()
+    autofig.plot(x=[1,2,3], y=[1,2,3], ylabel='blah')
+    autofig.plot(x=[1,2,3], y=[1,2,3], ylabel='OTHER')
+    assert(len(autofig.gcf().axes)==2)
+    assert(len(autofig.gcf().calls)==2)
+
 if __name__ == '__main__':
     test_unit_inconsistencies()
+    test_label_inconsistencies()


### PR DESCRIPTION
currently only supports x, y, z
unlike units, labels quietly allow None to avoid conflict