### PR TITLE
basic style-cycler support

### DIFF
--- a/autofig/axes.py
+++ b/autofig/axes.py
@@ -65,6 +65,18 @@ class Axes(object):
         return self._calls
 
     @property
+    def colorcycler(self):
+        return self._colorcycler
+
+    @property
+    def markercycler(self):
+        return self._markercycler
+
+    @property
+    def linestylecycler(self):
+        return self._linestylecycler
+
+    @property
     def fixed_limits(self):
         return self._fixed_limits
 
@@ -286,6 +298,8 @@ class Axes(object):
 
         # return_calls = []
         self._colorcycler.clear_tmp()
+        self._linestylecycler.clear_tmp()
+        self._markercycler.clear_tmp()
         for call in self.calls:
             if calls is None or call in calls:
                 artists = call.draw(ax=ax, i=i,

--- a/autofig/call.py
+++ b/autofig/call.py
@@ -119,8 +119,9 @@ class Plot(Call):
         color = kwargs.pop('color', None)
         c = color if color is not None else c
         self._c = CallDimensionC(self, c, None, cunit, clabel, cmap=cmap)
-
         # TODO: do the same for size??
+
+        self._axes = None # super will do this again, but we need it for setting marker, etc
         self._axes_c = None
 
         self.highlight = highlight
@@ -208,8 +209,10 @@ class Plot(Call):
     @color.setter
     def color(self, color):
         # TODO: type and cycler checks
-        # TODO: if axes attached, swap entry in cycler
-        self._c = _map_none(color)
+        color = _map_none(color)
+        if self.axes is not None:
+            self.axes._colorcycler.replace_used(self.get_color(), color)
+        self._c.value = color
 
     def get_marker(self, markercycler=None):
         marker = self._marker
@@ -227,8 +230,10 @@ class Plot(Call):
     @marker.setter
     def marker(self, marker):
         # TODO: type and cycler checks
-        # TODO: if axes attached, swap entry in cycler
-        self._marker = _map_none(marker)
+        marker = _map_none(marker)
+        if self.axes is not None:
+            self.axes._markercycler.replace_used(self.get_marker(), marker)
+        self._marker = marker
 
     def get_linestyle(self, linestylecycler=None):
         ls = self._linestyle
@@ -243,8 +248,10 @@ class Plot(Call):
     @linestyle.setter
     def linestyle(self, linestyle):
         # TODO: type and cycler checks
-        # TODO: if axes attached, swap entry in cycler
-        self._linestyle = _map_none(linestyle)
+        linestyle = _map_none(linestyle)
+        if self.axes is not None:
+            self.axes._linestylecycler.replace_used(self.get_linestyle(), linestyle)
+        self._linestyle = linestyle
 
     def draw(self, ax=None, i=None,
              colorcycler=None, markercycler=None, linestylecycler=None):
@@ -447,8 +454,13 @@ class CallDimension(object):
 
     def __repr__(self):
 
-        return "<{} | len: {} | type: {} | label: {}>".format(self.direction,
-                                       len(self.value) if self.value is not None else 'n/a',
+        if isinstance(self.value, str) or self.value is None:
+            info = "value: {}".format(self.value)
+        else:
+            info = "len: {}".format(len(self.value))
+
+        return "<{} | {} | type: {} | label: {}>".format(self.direction,
+                                       info,
                                        self.unit.physical_type,
                                        self.label)
 

--- a/autofig/call.py
+++ b/autofig/call.py
@@ -209,7 +209,7 @@ class Plot(Call):
     @color.setter
     def color(self, color):
         # TODO: type and cycler checks
-        color = _map_none(color)
+        color = common.coloralias.map(_map_none(color))
         if self.axes is not None:
             self.axes._colorcycler.replace_used(self.get_color(), color)
         self._c.value = color
@@ -248,7 +248,7 @@ class Plot(Call):
     @linestyle.setter
     def linestyle(self, linestyle):
         # TODO: type and cycler checks
-        linestyle = _map_none(linestyle)
+        linestyle = common.linestylealias.map(_map_none(linestyle))
         if self.axes is not None:
             self.axes._linestylecycler.replace_used(self.get_linestyle(), linestyle)
         self._linestyle = linestyle

--- a/autofig/common.py
+++ b/autofig/common.py
@@ -6,6 +6,28 @@ try:
 except NameError:
   basestring = str
 
+class Alias(object):
+    def __init__(self, dict):
+        self._dict = dict
+
+    def map(self, key):
+        return self._dict.get(key, key)
+
+
+# https://matplotlib.org/examples/color/named_colors.html
+# technically some of these (y, c, and m) don't exactly match, but as they "mean"
+# the same thing, we'll handle the alias anyways
+# Convention: always map to the spelled name and gray over grey
+coloralias = Alias({'k': 'black', 'dimgrey': 'dimgray', 'grey': 'gray',
+              'darkgrey': 'darkgray', 'lightgrey': 'lightgray',
+               'w': 'white', 'r': 'red', 'y': 'yellow', 'g': 'green',
+               'c': 'cyan', 'b': 'blue', 'm': 'magenta'})
+
+# Convention: always map to the spelled name
+linestylealias = Alias({'_': 'solid', '--': 'dashed', ':': 'dotted',
+                      '-.': 'dashdot'})
+
+
 def _convert_unit(unit):
     if unit is None:
         unit = u.dimensionless_unscaled

--- a/autofig/cyclers.py
+++ b/autofig/cyclers.py
@@ -1,11 +1,16 @@
 from matplotlib import colors, markers
+from . import common
 
-_mplcolors = ['k', 'b', 'r', 'g', 'p']
-_mplcolors = _mplcolors + [c for c in list(colors.ColorConverter.colors.keys()) + list(colors.cnames.keys()) if c not in _mplcolors]
+_mplcolors = ['black', 'blue', 'red', 'green', 'purple']
+_mplcolors = _mplcolors + [common.coloralias.map(c) for c in list(colors.ColorConverter.colors.keys()) + list(colors.cnames.keys()) if common.coloralias.map(c) not in _mplcolors]
 _mplmarkers = ['.', 'o', '+', 's', '*', 'v', '^', '<', '>', 'p', 'h', 'o', 'D']
 # could do matplotlib.markers.MarkerStyle.markers.keys()
 _mpllinestyles = ['solid', 'dashed', 'dotted', 'dashdot', 'None']
 # could also do matplotlib.lines.lineStyles.keys()
+
+
+
+
 
 class MPLPropCycler(object):
     def __init__(self, prop, options=[]):

--- a/autofig/cyclers.py
+++ b/autofig/cyclers.py
@@ -1,7 +1,7 @@
 from matplotlib import colors, markers
 
 _mplcolors = ['k', 'b', 'r', 'g', 'p']
-_mplcolors = _mplcolors + [c for c in colors.ColorConverter.colors.keys() + colors.cnames.keys() if c not in _mplcolors]
+_mplcolors = _mplcolors + [c for c in list(colors.ColorConverter.colors.keys()) + list(colors.cnames.keys()) if c not in _mplcolors]
 _mplmarkers = ['.', 'o', '+', 's', '*', 'v', '^', '<', '>', 'p', 'h', 'o', 'D']
 # could do matplotlib.markers.MarkerStyle.markers.keys()
 _mpllinestyles = ['solid', 'dashed', 'dotted', 'dashdot', 'None']

--- a/autofig/cyclers.py
+++ b/autofig/cyclers.py
@@ -1,0 +1,89 @@
+from matplotlib import colors, markers
+
+_mplcolors = ['k', 'b', 'r', 'g', 'p']
+_mplcolors = _mplcolors + [c for c in colors.ColorConverter.colors.keys() + colors.cnames.keys() if c not in _mplcolors]
+_mplmarkers = ['.', 'o', '+', 's', '*', 'v', '^', '<', '>', 'p', 'h', 'o', 'D']
+# could do matplotlib.markers.MarkerStyle.markers.keys()
+_mpllinestyles = ['solid', 'dashed', 'dotted', 'dashdot', 'None']
+# could also do matplotlib.lines.lineStyles.keys()
+
+class MPLPropCycler(object):
+    def __init__(self, options=[]):
+        self._options = options
+        self._used = []
+        self._used_tmp = []
+
+
+    @property
+    def options(self):
+        return self._options
+
+    @property
+    def used(self):
+        return list(set(self._used + self._used_tmp))
+
+    @property
+    def next(self):
+        for option in self.options:
+            if option not in self.used:
+                self.add_to_used(option)
+                return option
+        else:
+            return self.options[-1]
+
+    @property
+    def next_tmp(self):
+        for option in self.options:
+            if option not in self.used:
+                self.add_to_used_tmp(option)
+                return option
+        else:
+            return self.options[-1]
+
+    def get(self, option=None):
+        if option is not None:
+            self.add_to_used(option)
+            return option
+        else:
+            return self.next
+
+    def get_tmp(self, option=None):
+        if option is not None:
+            self.add_to_used_tmp(option)
+            return option
+        else:
+            return self.next_tmp
+
+    def add_to_used(self, option):
+        if option in [None, 'None', 'none']:
+            return
+        if option not in self.options:
+            raise ValueError("{} not one of {}".format(option, self.options))
+        if option not in self._used:
+            self._used.append(option)
+
+    def add_to_used_tmp(self, option):
+        if option in [None, 'None', 'none']:
+            return
+        if option not in self.options:
+            raise ValueError("{} not one of {}".format(option, self.options))
+        if option not in self._used_tmp:
+            self._used_tmp.append(option)
+
+    def clear_tmp(self):
+        self._used_tmp = []
+        return
+
+
+
+class MPLColorCycler(MPLPropCycler):
+    def __init__(self):
+        super(MPLColorCycler, self).__init__(options=_mplcolors)
+
+class MPLMarkerCycler(MPLPropCycler):
+    def __init__(self):
+        super(MPLMarkerCycler, self).__init__(options=_mplmarkers)
+
+class MPLLinestyleCycler(MPLPropCycler):
+    def __init__(self):
+        super(MPLLinestyleCycler, self).__init__(options=_mpllinestyles)

--- a/autofig/cyclers.py
+++ b/autofig/cyclers.py
@@ -76,6 +76,26 @@ class MPLPropCycler(object):
         if option not in self._used:
             self._used.append(option)
 
+    def replace_used(self, oldoption, newoption):
+        if newoption in [None, 'None', 'none']:
+            return
+        if newoption not in self._options_orig:
+            raise ValueError("{} not one of {}".format(newoption, self._options_orig))
+
+        if oldoption in self._used:
+            ind = self._used.index(oldoption)
+            self._used[ind] = newoption
+        elif oldoption in self._used_tmp:
+            # in many cases the old option may actually be in _used_tmp but
+            # None will be passed because we don't have access to the previous
+            # state of the color cycler.  But _used_tmp will be reset on the
+            # next draw anyways, so this doesn't really hurt anything.
+            self._used_tmp.remove(oldoption)
+            self.add_to_used(newoption)
+        else:
+            self.add_to_used(newoption)
+
+
     def add_to_used_tmp(self, option):
         if option in [None, 'None', 'none']:
             return

--- a/autofig/cyclers.py
+++ b/autofig/cyclers.py
@@ -8,15 +8,29 @@ _mpllinestyles = ['solid', 'dashed', 'dotted', 'dashdot', 'None']
 # could also do matplotlib.lines.lineStyles.keys()
 
 class MPLPropCycler(object):
-    def __init__(self, options=[]):
+    def __init__(self, prop, options=[]):
+        self._prop = prop
+        self._options_orig = options
         self._options = options
         self._used = []
         self._used_tmp = []
 
+    def __repr__(self):
+        return '<{}cycler | cycle: {} | used: {}>'.format(self._prop,
+                                                          self.cycle,
+                                                          self.used)
+
 
     @property
-    def options(self):
+    def cycle(self):
         return self._options
+
+    @cycle.setter
+    def cycle(self, cycle):
+        for option in cycle:
+            if option not in self._options_orig:
+                raise ValueError("invalid option: {}".format(option))
+        self._options = cycle
 
     @property
     def used(self):
@@ -24,7 +38,7 @@ class MPLPropCycler(object):
 
     @property
     def next(self):
-        for option in self.options:
+        for option in self.cycle:
             if option not in self.used:
                 self.add_to_used(option)
                 return option
@@ -33,7 +47,7 @@ class MPLPropCycler(object):
 
     @property
     def next_tmp(self):
-        for option in self.options:
+        for option in self.cycle:
             if option not in self.used:
                 self.add_to_used_tmp(option)
                 return option
@@ -57,16 +71,16 @@ class MPLPropCycler(object):
     def add_to_used(self, option):
         if option in [None, 'None', 'none']:
             return
-        if option not in self.options:
-            raise ValueError("{} not one of {}".format(option, self.options))
+        if option not in self._options_orig:
+            raise ValueError("{} not one of {}".format(option, self._options_orig))
         if option not in self._used:
             self._used.append(option)
 
     def add_to_used_tmp(self, option):
         if option in [None, 'None', 'none']:
             return
-        if option not in self.options:
-            raise ValueError("{} not one of {}".format(option, self.options))
+        if option not in self._options_orig:
+            raise ValueError("{} not one of {}".format(option, self._options_orig))
         if option not in self._used_tmp:
             self._used_tmp.append(option)
 
@@ -78,12 +92,12 @@ class MPLPropCycler(object):
 
 class MPLColorCycler(MPLPropCycler):
     def __init__(self):
-        super(MPLColorCycler, self).__init__(options=_mplcolors)
+        super(MPLColorCycler, self).__init__('color', options=_mplcolors)
 
 class MPLMarkerCycler(MPLPropCycler):
     def __init__(self):
-        super(MPLMarkerCycler, self).__init__(options=_mplmarkers)
+        super(MPLMarkerCycler, self).__init__('marker', options=_mplmarkers)
 
 class MPLLinestyleCycler(MPLPropCycler):
     def __init__(self):
-        super(MPLLinestyleCycler, self).__init__(options=_mpllinestyles)
+        super(MPLLinestyleCycler, self).__init__('linestyle', options=_mpllinestyles)

--- a/autofig/figure.py
+++ b/autofig/figure.py
@@ -101,7 +101,9 @@ class Figure(object):
 
         call = _call.Plot(*args, **kwargs)
         self.add_call(call)
-        return self.draw(calls=[call], tight_layout=tight_layout, show=show, save=save)
+        # return self.draw(calls=[call], tight_layout=tight_layout, show=show, save=save)
+        self.reset_draw()
+        return self.draw(tight_layout=tight_layout, show=show, save=save)
 
     def mesh(self, *args, **kwargs):
         """
@@ -113,13 +115,17 @@ class Figure(object):
 
         call = _call.Mesh(*args, **kwargs)
         self.add_call(call)
-        return self.draw(calls=[call], tight_layout=tight_layout, show=show, save=save)
+        # return self.draw(calls=[call], tight_layout=tight_layout, show=show, save=save)
+        self.reset_draw()
+        return self.draw(tight_layout=tight_layout, show=show, save=save)
 
     # def show(self):
     #     plt.show()
 
     def reset_draw(self):
         # TODO: figure options like figsize, etc
+        if self._backend_object is not None:
+            plt.close(self._backend_object)
         self._get_backend_object(fig=plt.figure())
 
     def draw(self, fig=None, i=None, calls=None,
@@ -145,7 +151,7 @@ class Figure(object):
                 ax = None
 
             axesi.draw(ax=ax, i=i, calls=calls, show=False, save=False)
-            
+
             self._backend_artists += axesi._get_backend_artists()
 
         # TODO: tight_layout conflicts with colorbars


### PR DESCRIPTION
colors, linestyles, and markers now cycle if not provided.  By implementing our own cycler we can ensure that any Call that requires multiple calls to the MPL backend will adhere to the same style and not multiple instances of MPLs cycler.